### PR TITLE
feat: auto generate evaluations from csv file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 
 .DS_Store
+scripts/

--- a/mkdocs_turing_plugins/contributors.py
+++ b/mkdocs_turing_plugins/contributors.py
@@ -113,6 +113,15 @@ class ContributorsPlugin(BasePlugin):
         return "1970-01-01"
 
     def _get_contributors(self, path: str) -> str:
+        contributors = self._fetch_contributors_from_github(path)
+        if "general" in path and not path.endswith("index.md"):
+            contributors.extend(
+                self._fetch_contributors_from_github("docs/general/data.csv")
+            )
+        raw = Template(CONTRIBUTORS_TEMPLATE).render(contributors=contributors)
+        return re.sub(r"(\n| {2,})", "", raw).strip()
+
+    def _fetch_contributors_from_github(self, path: str) -> list:
         fetch_url = f"https://github.com/ZJU-Turing/TuringCourses/contributors-list/master/{path}"
         contributors = []
         try:
@@ -135,6 +144,4 @@ class ContributorsPlugin(BasePlugin):
                     "avatar": result[1].split("?")[0],
                     "url": f"https://github.com/{result[0]}"
                 })
-        
-        raw = Template(CONTRIBUTORS_TEMPLATE).render(contributors=contributors)
-        return re.sub(r"(\n| {2,})", "", raw).strip()
+        return contributors

--- a/mkdocs_turing_plugins/evaluations.py
+++ b/mkdocs_turing_plugins/evaluations.py
@@ -1,0 +1,85 @@
+from mkdocs.config import config_options
+from mkdocs.plugins import BasePlugin
+from mkdocs.structure.pages import Page
+
+import csv
+from typing import Any, Dict
+
+template = """
+???+ general "*{score}* | {name}"
+{content}
+""".strip()
+
+class EvaluationsPlugin(BasePlugin):
+    config_scheme = (
+        ("enabled", config_options.Type(bool, default=True)),
+    )
+
+    enabled = True
+
+    art_tag = "![](https://img.shields.io/badge/-美育认定-blue?style=flat-square)"
+    lab_tag = "![](https://img.shields.io/badge/-劳育认定-brown?style=flat-square)"
+    
+    def on_config(self, config: config_options.Config, **kwargs) -> Dict[str, Any]:
+        if not self.enabled:
+            return config
+        
+        if not self.config.get("enabled"):
+            return config
+        
+        with open("docs/general/data.csv", "r", encoding="UTF-8") as f:
+            csv_reader = csv.DictReader(f)
+            self.items = list(csv_reader)
+            self.items.sort(key=lambda x: int(x["年级"]), reverse=True)
+
+    def on_page_markdown(
+        self, markdown: str, page: Page, config: config_options.Config, files, **kwargs
+    ) -> str:
+        if not self.enabled:
+            return markdown
+        
+        if not self.config.get("enabled"):
+            return markdown
+        
+        if not page.meta.get("evaluations"):
+            return markdown
+        
+        markdown += self._get_page_markdown(page.meta.get("evaluations").strip())
+
+        return markdown
+    
+    def _get_page_markdown(self, class_name: str) -> str:
+        markdown = ""
+        items = list(filter(lambda x: x["课程大类"] == class_name, self.items))
+        cat_list = list(map(lambda x: x["具体分类"], items))
+        cat_set = sorted(set(cat_list), key=cat_list.index)
+        for cat in cat_set:
+            markdown += f"## {cat}\n\n"
+            cat_items = list(filter(lambda x: x["具体分类"] == cat, items))
+            course_list = list(map(lambda x: x["课程名称"], cat_items))
+            course_set = sorted(set(course_list), key=course_list.index)
+            for course in course_set:
+                course_items = list(filter(lambda x: x["课程名称"] == course, cat_items))
+                grades_set = set(map(lambda x: int(x["年级"]), course_items))
+                if course_items[0]["美育认定"] == "True":
+                    markdown += f"### {course} {self.art_tag}\n\n"
+                elif course_items[0]["劳育认定"] == "True":
+                    markdown += f"### {course} {self.lab_tag}\n\n"
+                else:
+                    markdown += f"### {course}\n\n"
+                for grade in list(grades_set)[::-1]:
+                    markdown += f'=== "{grade} 级"\n'
+                    grade_items = list(filter(lambda x: int(x["年级"]) == grade, course_items))
+                    for item in grade_items:
+                        formated = template.format(
+                            score=item["评分"],
+                            name=item["姓名"] if item["姓名"].strip() else "匿名",
+                            content=self._indent(item["评价"])
+                        )
+                        markdown += self._indent(formated) + "\n"
+                markdown += "\n"
+        return markdown
+    
+    @staticmethod
+    def _indent(text: str, amount: int = 4) -> str:
+        return "\n".join(" " * amount + line for line in text.splitlines())

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'mkdocs.plugins': [
             'turing_changelog = mkdocs_turing_plugins.changelog:ChangelogPlugin',
             'turing_contributors = mkdocs_turing_plugins.contributors:ContributorsPlugin',
+            'turing_evaluations = mkdocs_turing_plugins.evaluations:EvaluationsPlugin',
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
Closes #4.

从 docs/general/data.csv 中读取数据，构建三个选修课评价页面。目前 csv 格式如下（UTF-8 编码，excel 需要注意）：

<img width="1802" alt="image" src="https://github.com/ZJU-Turing/TuringPlugins/assets/44120331/0d0912b8-00a6-489c-8ee9-576ee38d6731">

通识经验收集表需要按照这个格式来更新一下，方便导出到这个 csv 适应的格式。

待改进：添加一些附加 js 代码，实现评价的全部折叠/展开、按分类/课程/年级的筛选。